### PR TITLE
Fix required 'unit_of_measurement' field for homeassistant rest polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,19 @@ rest:
         unique_id: "d611314f-9010-4d0d-aa3b-37c7f350c82f"
         value_template: >
             {{ value | regex_findall_index("(?:rco2.*})(\d+)") }}
+        unit_of_measurement: "ppm"
       - name: "Temperature"
         unique_id: "d611314f-9010-4d0d-aa3b-37c7f350c821"
         device_class: temperature
         value_template: >
             {{ value | regex_findall_index("(?:atmp.*})((?:\d|\.)+)") }}
+        unit_of_measurement: "°C"
       - name: "Humidity"
         unique_id: "d611314f-9010-4d0d-aa3b-37c7f350c822"
         device_class: humidity
         value_template: >
             {{ value | regex_findall_index("(?:rhum.*})((?:\d|\.)+)") }}
+        unit_of_measurement: "%"
 ```
 
 # 3D-printed housing


### PR DESCRIPTION
### Problem
Homeassistant throws an error in the logs
### Error
"homeassistant.components.rest.sensor.RestSensor'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('carbon_dioxide') it is using; expected one of ['ppm']"

### Fix
Add unit_of_measurement parameter to REST sensor definition