### PR TITLE
ESP32 version Update 3.3.10 & storage fix

### DIFF
--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -17,9 +17,10 @@ jobs:
           platforms: |
             - name: esp32:esp32
               source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-              version: 3.3.7
+              version: 3.3.10
           libraries: |
             - name: FastLED
+              version: 3.10.3
             - name: Sensirion Core
             - name: Sensirion I2C SCD4x
             - name: WiFiManager

--- a/OpenCO2_Sensor.ino
+++ b/OpenCO2_Sensor.ino
@@ -10,7 +10,7 @@
    - WiFiManager: https://github.com/tzapu/WiFiManager
    - ArduinoMqttClient (if MQTT is defined)
 */
-#define VERSION "v6.1"
+#define VERSION "v6.2"
 
 #define HEIGHT_ABOVE_SEA_LEVEL 50             // Berlin
 #define TZ_DATA "CET-1CEST,M3.5.0,M10.5.0/3"  // Europe/Berlin time zone from https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv


### PR DESCRIPTION
Fix FastLED to library version 3.10.3 otherwise the storage is not sufficient